### PR TITLE
Install Tesseract packages in backend image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,13 @@ FROM python:3.11-slim
 WORKDIR /app
 
 COPY requirements.txt /app/requirements.txt
-RUN pip install --no-cache-dir -r /app/requirements.txt
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        tesseract-ocr \
+        tesseract-ocr-spa \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir -r /app/requirements.txt
 
 COPY . /app
 

--- a/backend/app/services/ocr_parser.py
+++ b/backend/app/services/ocr_parser.py
@@ -1,7 +1,11 @@
 # backend/app/services/ocr_parser.py
 from typing import Dict
+import logging
 import re
 import os
+
+
+logger = logging.getLogger(__name__)
 
 def _read_text(path: str) -> str:
     """Lee texto de PDF (si tiene texto) o de imagen (si hay Tesseract). Devuelve '' si no puede."""
@@ -16,6 +20,7 @@ def _read_text(path: str) -> str:
                 pages = [p.extract_text() or "" for p in pdf.pages]
             text = "\n".join(pages)
         except Exception:
+            logger.exception("No se pudo extraer texto embebido del PDF %s", path)
             text = ""
 
     # Imagen con OCR (opcional)
@@ -28,6 +33,7 @@ def _read_text(path: str) -> str:
             img = img.convert("L")
             text = pytesseract.image_to_string(img, lang="spa")
         except Exception:
+            logger.exception("Error realizando OCR sobre la imagen %s", path)
             text = ""
 
     return text or ""


### PR DESCRIPTION
## Summary
- install the tesseract engine and Spanish language package in the backend Docker image before Python dependencies
- add logging to OCR text reading errors to ease debugging of parsing failures

## Testing
- docker build -t conta-backend:latest backend *(fails: docker not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de73275064832d87325db41ffce911